### PR TITLE
Adds alt implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bower_components
 facebook-flux/build
 yahoo-fluxible/build
 reflux/build
+alt/build

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The list of Flux related implementations used in this demo.
 * [x] [Original Facebook Flux](https://github.com/voronianski/flux-samples/tree/master/facebook-flux)
 * [x] [Fluxible by Yahoo](https://github.com/voronianski/flux-samples/tree/master/yahoo-fluxible)
 * [x] [Reflux](https://github.com/voronianski/flux-samples/tree/master/reflux)
+* [x] [Alt](https://github.com/voronianski/flux-samples/tree/master/alt)
 
 ### Next
 
@@ -46,6 +47,7 @@ The list of Flux related implementations used in this demo.
 - https://github.com/yahoo/fluxible
 - https://github.com/yahoo/dispatchr
 - https://github.com/spoike/refluxjs
+- https://github.com/goatslacker/alt
 - http://fluxxor.com
 - http://martyjs.org
 - http://deloreanjs.com

--- a/alt/index.html
+++ b/alt/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Alt Sample</title>
+
+    <link rel="shortcut icon" type="image/png" href="../common/assets/react.png">
+    <link rel="stylesheet" href="../common/css/uikit.almost-flat.min.css">
+    <link rel="stylesheet" href="../common/css/main.css">
+</head>
+<body>
+    <div id="flux-app"></div>
+
+    <script src="build/bundle.js"></script>
+</body>
+</html>

--- a/alt/js/actions/ActionCreators.js
+++ b/alt/js/actions/ActionCreators.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var alt = require('../alt');
+var WebAPIUtils = require('../utils/WebAPIUtils');
+
+class ActionsCreators {
+    constructor() {
+        this.generateActions(
+            'receiveProducts',
+            'addToCart',
+            'finishCheckout'
+        );
+    }
+
+    cartCheckout(products) {
+        this.dispatch(products);
+        WebAPIUtils.checkoutProducts(products);
+    }
+}
+
+alt.createActions(ActionsCreators, exports);

--- a/alt/js/alt.js
+++ b/alt/js/alt.js
@@ -1,0 +1,2 @@
+var Alt = require('alt');
+module.exports = new Alt();

--- a/alt/js/app.js
+++ b/alt/js/app.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('es5-shim');
+require('es5-shim/es5-sham');
+
+var React = require('react');
+var App = require('./components/App.jsx');
+
+var WebAPIUtils = require('./utils/WebAPIUtils');
+
+WebAPIUtils.getAllProducts();
+
+React.render(
+    React.createElement(App, null),
+    document.getElementById('flux-app')
+);

--- a/alt/js/components/App.jsx
+++ b/alt/js/components/App.jsx
@@ -1,0 +1,18 @@
+'use strict';
+
+var React = require('react');
+var Cart = require('./Cart.jsx');
+var Products = require('./Products.jsx');
+
+var App = React.createClass({
+    render: function () {
+        return (
+            <div>
+                <Products />
+                <Cart />
+            </div>
+        );
+    }
+});
+
+module.exports = App;

--- a/alt/js/components/Cart.jsx
+++ b/alt/js/components/Cart.jsx
@@ -1,0 +1,69 @@
+'use strict';
+
+var React = require('react');
+var CartStore = require('../stores/CartStore');
+var ActionCreators = require('../actions/ActionCreators');
+
+function _getStateFromStores () {
+    return {
+        products: CartStore.getAddedProducts(),
+        total: CartStore.getTotal()
+    };
+}
+
+var Product = React.createClass({
+    render: function () {
+        return <div>{this.props.children}</div>;
+    }
+});
+
+var Cart = React.createClass({
+    getInitialState: function () {
+        return _getStateFromStores();
+    },
+
+    componentDidMount: function () {
+        CartStore.listen(this._onChange);
+    },
+
+    componentWillUnmount: function () {
+        CartStore.unlisten(this._onChange);
+    },
+
+    checkout: function () {
+        if (!this.state.products.length) {
+            return;
+        }
+        ActionCreators.cartCheckout(this.state.products);
+    },
+
+    render: function () {
+        var products = this.state.products;
+
+        var hasProducts = products.length > 0;
+        var nodes = !hasProducts ?
+            <div>Please add some products to cart.</div> :
+            products.map(function (p) {
+                return <Product key={p.id}>{p.title} - &euro;{p.price} x {p.quantity}</Product>;
+            });
+
+        return (
+            <div className="cart uk-panel uk-panel-box uk-panel-box-primary">
+                <div className="uk-badge uk-margin-bottom">Your Cart</div>
+                <div className="uk-margin-small-bottom">{nodes}</div>
+                <div className="uk-margin-small-bottom">Total: &euro;{this.state.total}</div>
+                <button className="uk-button uk-button-large uk-button-success uk-align-right"
+                    onClick={this.checkout}
+                    disabled={hasProducts ? '' : 'disabled'}>
+                    Checkout
+                </button>
+            </div>
+        );
+    },
+
+    _onChange: function () {
+        this.setState(_getStateFromStores());
+    }
+});
+
+module.exports = Cart;

--- a/alt/js/components/Products.jsx
+++ b/alt/js/components/Products.jsx
@@ -1,0 +1,64 @@
+'use strict';
+
+var React = require('react');
+var ProductStore = require('../stores/ProductStore');
+var ActionCreators = require('../actions/ActionCreators');
+
+function _getStateFromStores () {
+    return ProductStore.getState();
+}
+
+var ProductItem = React.createClass({
+    addToCart: function () {
+        ActionCreators.addToCart(this.props.product);
+    },
+
+    render: function () {
+        var product = this.props.product;
+
+        return (
+            <div className="uk-panel uk-panel-box uk-margin-bottom">
+                <img className="uk-thumbnail uk-thumbnail-mini uk-align-left" src={product.image} />
+                <h4 className="uk-h4">{product.title} - &euro;{product.price}</h4>
+                <button className="uk-button uk-button-small uk-button-primary"
+                    onClick={this.addToCart}
+                    disabled={product.inventory > 0 ? '' : 'disabled'}>
+                    {product.inventory > 0 ? 'Add to cart' : 'Sold Out'}
+                </button>
+            </div>
+        );
+    }
+});
+
+var ProductsList = React.createClass({
+    getInitialState: function () {
+        return _getStateFromStores();
+    },
+
+    componentDidMount: function () {
+        ProductStore.listen(this._onChange);
+    },
+
+    componentWillUnmount: function () {
+        ProductStore.unlisten(this._onChange);
+    },
+
+    render: function () {
+        var nodes = this.state.products.map(function (product) {
+            return <ProductItem key={product.id} product={product} />;
+        });
+
+        return (
+            <div className="shop-wrap">
+                <h2 className="uk-h2">Flux Shop Demo (Facebook)</h2>
+                <div>{nodes}</div>
+            </div>
+        );
+    },
+
+    _onChange: function () {
+        this.setState(_getStateFromStores());
+    }
+});
+
+module.exports = ProductsList;

--- a/alt/js/stores/CartStore.js
+++ b/alt/js/stores/CartStore.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var alt = require('../alt');
+
+var ActionCreators = require('../actions/ActionCreators');
+var ProductStore = require('./ProductStore');
+var assign = require('object-assign');
+
+class CartStore {
+    constructor() {
+        this.bindActions(ActionCreators);
+        this.products = {};
+    }
+
+    onAddToCart(product) {
+        this.waitFor(ProductStore.dispatchToken);
+        var id = product.id;
+        product.quantity = id in this.products ? this.products[id].quantity + 1 : 1;
+        this.products[id] = assign({}, product[id], product);
+    }
+
+    onCartCheckout() {
+        this.products = {};
+    }
+
+    onFinishCheckout(products) {
+        // this can be used to redirect to success page, etc.
+        console.log('YOU BOUGHT:', products);
+    }
+
+    static getAddedProducts() {
+        var { products } = this.getState();
+        return Object.keys(products).map(function (id) {
+            return products[id];
+        });
+    }
+
+    static getTotal() {
+        var total = 0;
+        var { products } = this.getState();
+        for (var id in products) {
+            var product = products[id];
+            total += product.price * product.quantity;
+        }
+        return total.toFixed(2);
+    }
+}
+
+module.exports = alt.createStore(CartStore, 'CartStore');

--- a/alt/js/stores/ProductStore.js
+++ b/alt/js/stores/ProductStore.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var alt = require('../alt');
+
+var ActionCreators = require('../actions/ActionCreators');
+
+class ProductStore {
+    constructor() {
+        this.bindActions(ActionCreators);
+        this.products = [];
+    }
+
+    decreaseInventory(product) {
+        product.inventory = product.inventory > 0 ? product.inventory-1 : 0;
+    }
+
+    onAddToCart(product) {
+        this.decreaseInventory(product);
+    }
+
+    onReceiveProducts(products) {
+        this.products = products;
+    }
+}
+
+module.exports = alt.createStore(ProductStore, 'ProductStore');

--- a/alt/js/utils/WebAPIUtils.js
+++ b/alt/js/utils/WebAPIUtils.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var shop = require('../../../common/api/shop');
+var ActionCreators = require('../actions/ActionCreators');
+
+module.exports = {
+    getAllProducts: function () {
+        shop.getProducts(function (products) {
+            ActionCreators.receiveProducts(products);
+        });
+    },
+
+    checkoutProducts: function (products) {
+        shop.buyProducts(products, function () {
+            ActionCreators.finishCheckout(products);
+        });
+    }
+};

--- a/alt/package.json
+++ b/alt/package.json
@@ -1,0 +1,15 @@
+{
+  "main": "js/app.js",
+  "scripts": {
+    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
+    "build": "browserify js/app.js > build/bundle.js"
+  },
+  "browserify": {
+    "transform": [
+      "6to5ify",
+      "reactify",
+      "envify"
+    ]
+  },
+  "dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Dmitri Voronianski <dmitri.voronianski@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "alt": "^0.10.1",
     "array.prototype.find": "^1.0.0",
     "es5-shim": "^4.0.6",
     "flux": "^2.0.1",
@@ -22,6 +23,8 @@
     "reflux": "^0.2.4"
   },
   "devDependencies": {
+    "6to5": "^3.3.4",
+    "6to5ify": "^4.0.0",
     "browserify": "^8.0.3",
     "envify": "^3.2.0",
     "reactify": "^0.17.1",


### PR DESCRIPTION
Hi there!

Your project is a great "todomvc" of flux implementations, this is a neat idea and I can't wait to read your blog post.

This PR adds the [alt](https://github.com/goatslacker/alt) implementation for comparison. Alt is a terse flux implementation, similar to reflux I guess, but it's actually 100% flux. It's got tests, docs, and it's being used in production right now.

Alt is meant to be used with ES6 although it's not necessary. I can actually provide a non ES6 example. In this PR I'm using [6to5](http://6to5.org) to transpile the code with browserify.

I tested this PR by
- cloning a fresh repo
- run `npm install`
- run `npm start`
- `open index.html`
- clicked on 2 iPads and verified they sold out.
- clicked on 1 shirt
- checkout
- verified console that correct items were logged
