### PR TITLE
Add examples by non-react links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The list of Flux related implementations used in this demo.
 * [ ] Fluxxor
 * [ ] Delorean.js
 
+## Examples by non-react libraries
+
+* [Riot + RiotControl] https://github.com/txchen/feplay/tree/gh-pages/riot_flux
+
 ## Resources
 
 ### Libraries

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The list of Flux related implementations used in this demo.
 
 ## Examples by non-react libraries
 
-* [Riot + RiotControl] https://github.com/txchen/feplay/tree/gh-pages/riot_flux
+* [Riot + RiotControl]https://github.com/txchen/feplay/tree/gh-pages/riot_flux
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The list of Flux related implementations used in this demo.
 
 ## Examples by non-react libraries
 
-* [Riot + RiotControl]https://github.com/txchen/feplay/tree/gh-pages/riot_flux
+* [Riot + RiotControl](https://github.com/txchen/feplay/tree/gh-pages/riot_flux)
 
 ## Resources
 


### PR DESCRIPTION
Hi, thanks for creating this repo, it is really useful.

I am created a similar example by using Riot + RiotControl. Maybe this can also be useful when people are evaluating how to implement flux?
