### PR TITLE
Update Flummox to 2.6 and use new mixin

### DIFF
--- a/flummox/js/components/CartContainer.jsx
+++ b/flummox/js/components/CartContainer.jsx
@@ -1,43 +1,23 @@
 'use strict';
 
 import React from 'react';
+import FluxMixin from 'flummox/mixin'
 import Cart from '../../../common/components/Cart.jsx';
 
 let CartContainer = React.createClass({
 
-    getInitialState() {
-        this.actions = this.props.flux.getActions('app');
-        this.cartStore = this.props.flux.getStore('cart');
-
-        return this.getStateFromStores();
-    },
-
-    getStateFromStores() {
-        return {
-            products: this.cartStore.getProducts(),
-            total: this.cartStore.getTotal(),
-        };
-    },
-
-    componentDidMount() {
-        this.cartStore.addListener('change', this.onStoreChange);
-    },
-
-    componentWillUnmount() {
-        this.cartStore.removeListener('change', this.onStoreChange);
-    },
-
-    onStoreChange() {
-        this.setState(
-            this.getStateFromStores()
-        );
-    },
+    mixins: [FluxMixin({
+        cart: store => ({
+            products: store.getProducts(),
+            total: store.getTotal()
+        })
+    })],
 
     onCheckoutClicked() {
         if (!this.state.products.length) {
             return;
         }
-        this.actions.cartCheckout(this.state.products);
+        this.flux.getActions('app').cartCheckout(this.state.products);
     },
 
     render() {

--- a/flummox/js/components/ProductsContainer.jsx
+++ b/flummox/js/components/ProductsContainer.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import FluxMixin from 'flummox/mixin'
 import ProductItem from '../../../common/components/ProductItem.jsx';
 import ProductsList from '../../../common/components/ProductsList.jsx';
 
@@ -23,32 +24,11 @@ let ProductItemContainer = React.createClass({
 
 let ProductsListContainer = React.createClass({
 
-    getInitialState() {
-        this.actions = this.props.flux.getActions('app');
-        this.productStore = this.props.flux.getStore('products');
-
-        return this.getStateFromStores();
-    },
-
-    getStateFromStores() {
-        return {
-            products: this.productStore.getProducts(),
-        };
-    },
-
-    componentDidMount() {
-        this.productStore.addListener('change', this.onStoreChange);
-    },
-
-    componentWillUnmount() {
-        this.productStore.removeListener('change', this.onStoreChange);
-    },
-
-    onStoreChange() {
-        this.setState(
-            this.getStateFromStores()
-        );
-    },
+    mixins: [FluxMixin({
+        products: store => ({
+            products: store.getProducts(),
+        })
+    })],
 
     render() {
         let nodes = this.state.products.map(product => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "alt": "^0.10.1",
     "array.prototype.find": "^1.0.0",
     "es5-shim": "^4.0.6",
-    "flummox": "~2.2.1",
+    "flummox": "~2.6.0",
     "flux": "^2.0.1",
     "fluxible": "^0.2.0",
     "marty": "^0.8.9",


### PR DESCRIPTION
This updates Flummox to the most recent version, which includes a nifty mixin for subscribing to store changes. Lets us get rid of a lot of boilerplate — look at all that red :)
