### PR TITLE
remove redundant merge parameter from Object.assign()

### DIFF
--- a/alt/js/stores/CartStore.js
+++ b/alt/js/stores/CartStore.js
@@ -16,7 +16,7 @@ class CartStore {
         this.waitFor(ProductStore.dispatchToken);
         var id = product.id;
         product.quantity = id in this.products ? this.products[id].quantity + 1 : 1;
-        this.products[id] = assign({}, product[id], product);
+        this.products[id] = assign({}, product);
     }
 
     onCartCheckout() {

--- a/facebook-flux/js/stores/CartStore.js
+++ b/facebook-flux/js/stores/CartStore.js
@@ -15,7 +15,7 @@ var _products = {};
 function _addToCart (product) {
     var id = product.id;
     product.quantity = id in _products ? _products[id].quantity + 1 : 1;
-    _products[id] = assign({}, product[id], product);
+    _products[id] = assign({}, product);
 }
 
 var CartStore = assign({}, EventEmitter.prototype, {

--- a/marty/js/stores/CartStore.js
+++ b/marty/js/stores/CartStore.js
@@ -21,7 +21,7 @@ class CartStore extends Marty.Store {
 
         var id = product.id;
         product.quantity = id in this.state ? this.state[id].quantity + 1 : 1;
-        this.state[id] = assign({}, product[id], product);
+        this.state[id] = assign({}, product);
         this.hasChanged();
     }
 

--- a/mcfly/js/stores/CartStore.js
+++ b/mcfly/js/stores/CartStore.js
@@ -10,7 +10,7 @@ var _products = {};
 function _addToCart (product) {
     var id = product.id;
     product.quantity = id in _products ? _products[id].quantity + 1 : 1;
-    _products[id] = assign({}, product[id], product);
+    _products[id] = assign({}, product);
 }
 
 var CartStore = McFly.createStore({

--- a/redux/js/stores/CartStore.js
+++ b/redux/js/stores/CartStore.js
@@ -1,7 +1,7 @@
 import { ADD_TO_CART, BEGIN_CHECKOUT, SUCCESS_CHECKOUT } from '../constants/ActionTypes';
 
 function _addToCart (state, product) {
-    let cartProduct = Object.assign({}, product[id], product);
+    let cartProduct = Object.assign({}, product);
     let { id } = cartProduct;
 
     cartProduct.quantity = id in state ? state[id].quantity + 1 : 1;

--- a/reflux/js/stores/CartStore.js
+++ b/reflux/js/stores/CartStore.js
@@ -20,7 +20,7 @@ var CartStore = Reflux.createStore({
         var id = product.id;
 
         product.quantity = id in this._products ? this._products[id].quantity + 1 : 1;
-        this._products[id] = assign({}, product[id], product);
+        this._products[id] = assign({}, product);
         this.trigger(this.getAddedProducts(), this.getTotal());
     },
 

--- a/yahoo-fluxible/js/stores/CartStore.js
+++ b/yahoo-fluxible/js/stores/CartStore.js
@@ -22,7 +22,7 @@ var CartStore = createStore({
             var id = product.id;
 
             product.quantity = id in this._products ? this._products[id].quantity + 1 : 1;
-            this._products[id] = assign({}, product[id], product);
+            this._products[id] = assign({}, product);
             this.emitChange();
         }.bind(this));
     },


### PR DESCRIPTION
Here's an oddity that I just picked up on. Causes no ill effects because `id` appears to be declared somewhere and `Object.assign()` doesn't care that `undefined` doesn't have any keys.
