### PR TITLE
Add dependency on util-deprecate

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "envify": "^3.2.0",
     "reactify": "^0.17.1",
     "uglify-js": "^2.4.16",
+    "util-deprecate": "^1.0.1",
     "watchify": "^2.2.1"
   },
   "browserify": {


### PR DESCRIPTION
This fixes `npm start` failing when `node_modules/watchify/node_modules/browserify/node_modules/readable-stream/lib/_stream_writable.js` `require()`s util-deprecate.

Full text of the error that this fixes:

```
> @ start /Users/francis/Code/JavaScript/flux-comparison/redux
> ../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d

module.js:338
    throw err;
          ^
Error: Cannot find module 'util-deprecate'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/francis/Code/JavaScript/flux-comparison/node_modules/watchify/node_modules/browserify/node_modules/readable-stream/lib/_stream_writable.js:143:8)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)

npm ERR! Darwin 14.5.0
npm ERR! argv "/opt/local/bin/node" "/opt/local/bin/npm" "start"
npm ERR! node v0.12.7
npm ERR! npm  v2.14.3
npm ERR! code ELIFECYCLE
npm ERR! @ start: `../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ start script '../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d'.
npm ERR! This is most likely a problem with the  package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     ../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d
npm ERR! You can get their info via:
npm ERR!     npm owner ls 
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/francis/Code/JavaScript/flux-comparison/redux/npm-debug.log
```
