### PR TITLE
Replace usage of react/lib/keyMirror with keymirror

### DIFF
--- a/facebook-flux/js/constants/AppConstants.js
+++ b/facebook-flux/js/constants/AppConstants.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var keyMirror = require('react/lib/keyMirror');
+var keyMirror = require('keymirror');
 
 module.exports = {
     ActionTypes: keyMirror({

--- a/facebook-flux/package.json
+++ b/facebook-flux/package.json
@@ -9,5 +9,7 @@
       "envify"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "keymirror": "^0.1.1"
+  }
 }

--- a/nuclear-js/js/action-types.js
+++ b/nuclear-js/js/action-types.js
@@ -1,4 +1,4 @@
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'keymirror';
 
 export default keyMirror({
     RECEIVE_PRODUCTS: null,

--- a/nuclear-js/package.json
+++ b/nuclear-js/package.json
@@ -10,5 +10,7 @@
       "envify"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "keymirror": "^0.1.1"
+  }
 }

--- a/redux/js/constants/ActionTypes.js
+++ b/redux/js/constants/ActionTypes.js
@@ -1,4 +1,4 @@
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'keymirror';
 
 export default keyMirror({
     RECEIVE_PRODUCTS: null,

--- a/redux/package.json
+++ b/redux/package.json
@@ -1,22 +1,24 @@
 {
-    "main": "js/app.js",
-    "scripts": {
-        "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-        "build": "browserify js/app.js > build/bundle.js"
-    },
-    "browserify": {
-        "transform": [
-            [
-                "babelify",
-                {
-                    "stage": 2,
-                    "optional": [
-                        "runtime"
-                    ]
-                }
-            ],
-            "envify"
-        ]
-    },
-    "dependencies": {}
+  "main": "js/app.js",
+  "scripts": {
+    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
+    "build": "browserify js/app.js > build/bundle.js"
+  },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "stage": 2,
+          "optional": [
+            "runtime"
+          ]
+        }
+      ],
+      "envify"
+    ]
+  },
+  "dependencies": {
+    "keymirror": "^0.1.1"
+  }
 }


### PR DESCRIPTION
React does not encourage people to use its internals. While technically `react/lib/keyMirror` works we shouldn't rely on it, and should use `keymirror` NPM module instead. This is what official Flux examples also do.
