### PR TITLE
Add ESLint as "npm run lint" and remaining fix lint issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+**/node_modules/*
+**/build/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,9 @@
     "no-unused-vars": 1,
     "no-unused-expressions": 0,
     "react/jsx-no-undef": 2,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/react-in-jsx-scope": 2,
     "new-cap": 0,
     "no-shadow": 0,
     "no-use-before-define": 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,15 @@ You're free to choose whether you want to use latest _ECMAScript6_ features (the
 - use semicolons
 - don't use comma-first notation
 
+You can run
+
+```
+npm install
+npm run lint
+```
+
+in the root directory to make sure that your coding style matches these rules.
+
 ##### These tools will help your IDE to remind you with some of the rules listed above:
 
 - [EditorConfig](http://editorconfig.org)

--- a/lux/js/app.js
+++ b/lux/js/app.js
@@ -6,7 +6,6 @@ require('babel/polyfill');
 
 var React = require('react');
 var lux = require('lux.js');
-var WebAPIUtils = require('./utils/WebAPIUtils');
 var App = require('./components/App.jsx');
 
 lux.publishAction('getAllProducts');

--- a/marty/js/queries/shopQueries.js
+++ b/marty/js/queries/shopQueries.js
@@ -5,11 +5,11 @@ var ShopAPI = require('../sources/shopAPI');
 var ProductConstants = require('../constants/productConstants');
 
 class ShopQueries extends Marty.Queries {
-  getAllProducts() {
-    return ShopAPI.getAllProducts()
-      .then(products =>  this.dispatch(ProductConstants.RECEIVE_PRODUCTS, products))
-      .catch(error => this.dispatch(ProductConstants.RECEIVE_PRODUCTS_FAILED, error));
-  }
+    getAllProducts() {
+        return ShopAPI.getAllProducts()
+            .then(products =>  this.dispatch(ProductConstants.RECEIVE_PRODUCTS, products))
+            .catch(error => this.dispatch(ProductConstants.RECEIVE_PRODUCTS_FAILED, error));
+    }
 }
 
 module.exports = Marty.register(ShopQueries);

--- a/nuclear-js/js/getters.js
+++ b/nuclear-js/js/getters.js
@@ -1,7 +1,7 @@
 const products = [
     ['products'],
     products => {
-      return products.toList().toJS();
+        return products.toList().toJS();
     }
 ];
 

--- a/nuclear-js/js/stores/CartStore.js
+++ b/nuclear-js/js/stores/CartStore.js
@@ -42,7 +42,7 @@ function beginCheckout(state) {
         .set('pendingCheckout', currentItems);
 }
 
-function finishCheckout(state) {
+function finishCheckout() {
     return initialState;
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "description": "Flux architecture samples and solutions",
   "scripts": {
-    "build": "NODE_ENV=production browserify ./facebook-flux/js/app.js | uglifyjs -cm > ./facebook-flux/build/bundle.min.js"
+    "build": "NODE_ENV=production browserify ./facebook-flux/js/app.js | uglifyjs -cm > ./facebook-flux/build/bundle.min.js",
+    "lint": "eslint ."
   },
   "keywords": [
     "react",

--- a/redux/js/actions/ActionCreators.js
+++ b/redux/js/actions/ActionCreators.js
@@ -2,7 +2,7 @@ import ActionTypes from '../constants/ActionTypes';
 import shop from '../../../common/api/shop';
 
 export function getAllProducts() {
-    return (dispatch, getState) => {
+    return (dispatch) => {
         dispatch({
             type: ActionTypes.GET_ALL_PRODUCTS
         });
@@ -28,7 +28,7 @@ export function addToCart(product) {
 }
 
 export function beginCheckout(products) {
-    return (dispatch, getState) => {
+    return (dispatch) => {
         dispatch({
             type: ActionTypes.BEGIN_CHECKOUT
         });

--- a/redux/js/components/App.jsx
+++ b/redux/js/components/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import { connect } from 'react-redux';
 import ProductsContainer from './ProductsContainer.jsx';
 import CartContainer from './CartContainer.jsx';

--- a/redux/js/components/CartContainer.jsx
+++ b/redux/js/components/CartContainer.jsx
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { beginCheckout } from '../actions/ActionCreators';

--- a/redux/js/components/ProductsContainer.jsx
+++ b/redux/js/components/ProductsContainer.jsx
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { addToCart } from '../actions/ActionCreators';


### PR DESCRIPTION
This fixes the current lint issues found with the latest ESLint version and adds `npm run lint` command to `package.json` to ensure we don't regress on those.
