### PR TITLE
Move Redux dependencies to its own package.json and tweak the build

### DIFF
--- a/alt/package.json
+++ b/alt/package.json
@@ -1,8 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/facebook-flux/package.json
+++ b/facebook-flux/package.json
@@ -1,7 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/flummox/package.json
+++ b/flummox/package.json
@@ -1,8 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/fluxette/package.json
+++ b/fluxette/package.json
@@ -1,8 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/fluxxor/package.json
+++ b/fluxxor/package.json
@@ -1,8 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/lux/package.json
+++ b/lux/package.json
@@ -1,7 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/marty/package.json
+++ b/marty/package.json
@@ -1,7 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/material-flux/package.json
+++ b/material-flux/package.json
@@ -1,8 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/mcfly/package.json
+++ b/mcfly/package.json
@@ -1,7 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/nuclear-js/package.json
+++ b/nuclear-js/package.json
@@ -1,8 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js js/app.js -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -31,11 +31,8 @@
     "nuclear-js": "^1.0.5",
     "object-assign": "^2.0.0",
     "react": "^0.13.0",
-    "react-redux": "^0.2.2",
     "react-router": "^0.13.0",
     "reducer": "^0.19.2",
-    "redux": "^1.0.0-rc",
-    "redux-thunk": "^0.1.0",
     "reflux": "^0.2.4"
   },
   "devDependencies": {

--- a/redux/package.json
+++ b/redux/package.json
@@ -2,7 +2,7 @@
   "main": "js/app.js",
   "scripts": {
     "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
-    "build": "browserify js/app.js > build/bundle.js"
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [
@@ -19,6 +19,10 @@
     ]
   },
   "dependencies": {
-    "keymirror": "^0.1.1"
+    "keymirror": "^0.1.1",
+    "react": "^0.13.0",
+    "react-redux": "^0.2.2",
+    "redux": "^1.0.0-rc",
+    "redux-thunk": "^0.1.0"
   }
 }

--- a/redux/package.json
+++ b/redux/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "flux-comparison-redux",
   "main": "js/app.js",
   "scripts": {
     "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",

--- a/redux/package.json
+++ b/redux/package.json
@@ -1,7 +1,7 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d",
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
     "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {

--- a/reflux/package.json
+++ b/reflux/package.json
@@ -1,7 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [

--- a/yahoo-fluxible/package.json
+++ b/yahoo-fluxible/package.json
@@ -1,7 +1,8 @@
 {
   "main": "js/app.js",
   "scripts": {
-    "start": "../node_modules/watchify/bin/cmd.js . -o build/bundle.js -v -d"
+    "start": "../node_modules/.bin/watchify . -o build/bundle.js -v -d",
+    "build": "../node_modules/.bin/browserify js/app.js > build/bundle.js"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This moves Redux dependencies to its own `package.json` as discussed in https://github.com/voronianski/flux-comparison/issues/62. I didn't bother doing this for `browserify`/`babelify`/`watchify` because the build infrastructure is common anyway and I don't want to introduce version mismatch at this point.

However in the second commit I fixed all repos to call `watchify` and `browserify` in the same way, and also to use `.bin/watchify` instead of direct call inside it. I also fixed `browserify` to be called with relative path so it doesn't fail on systems that have no global `browserify`.
